### PR TITLE
Update pricing plans and newsletter translations

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -27,16 +27,16 @@
     },
     "pricing": {
       "title": "Choose Your Development Plan",
-      "basic": {
-        "name": "Basic",
-        "price": "$5",
+      "pro": {
+        "name": "Pro",
+        "price": "$10",
         "period": "per month",
-        "description": "Includes",
+        "description": "Perfect for growing teams",
         "features": [
-          "5 automation packages",
-          "Unlimited assets",
-          "Unlimited agent",
-          "Multi-tenant",
+          "10 automation packages upload",
+          "5 agent creation",
+          "1 organization unit creation",
+          "100 AI assistant messages",
           "Real-time monitoring",
           "Execution logging",
           "Scheduling",
@@ -44,19 +44,20 @@
           "User roles and permissions"
         ]
       },
-      "premium": {
-        "name": "Premium",
-        "price": "$10",
+      "ultra": {
+        "name": "Ultra",
+        "price": "$20",
         "period": "per month",
-        "description": "Everything in Basic, plus",
-        "features": ["10 packages automation", "Chatbot AI  support"]
-      },
-      "enterprise": {
-        "name": "Enterprise",
-        "price": "Contact us",
-        "period": "per month",
-        "description": "For large enterprise",
-        "features": ["Dedicated support team", "Enterprise-grade security"]
+        "description": "Advanced features for scaling businesses",
+        "features": [
+          "20 automation packages upload",
+          "10 agent creation",
+          "3 organization units creation",
+          "200 AI assistant messages",
+          "Everything in Pro",
+          "Priority support",
+          "Advanced analytics"
+        ]
       }
     },
     "faq": {

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -26,16 +26,16 @@
     },
     "pricing": {
       "title": "Chọn gói phát triển của bạn",
-      "basic": {
-        "name": "Cơ bản",
-        "price": "$5",
+      "pro": {
+        "name": "Pro",
+        "price": "$10",
         "period": "mỗi tháng",
-        "description": "Bao gồm",
+        "description": "Hoàn hảo cho đội ngũ đang phát triển",
         "features": [
-          "5 gói tự động hóa",
-          "Tài sản không giới hạn",
-          "Agent không giới hạn",
-          "Hỗ trợ đa tenant",
+          "10 gói tự động hóa upload",
+          "5 agent tạo mới",
+          "1 đơn vị tổ chức tạo mới",
+          "100 tin nhắn trợ lý AI",
           "Giám sát thời gian thực",
           "Ghi nhật ký thực thi",
           "Lập lịch",
@@ -43,19 +43,20 @@
           "Vai trò và phân quyền người dùng"
         ]
       },
-      "premium": {
-        "name": "Cao cấp",
-        "price": "$10",
+      "ultra": {
+        "name": "Ultra",
+        "price": "$20",
         "period": "mỗi tháng",
-        "description": "Mọi thứ trong gói Cơ bản, cộng thêm",
-        "features": ["10 gói tự động hoá", "Hỗ trợ Chatbot AI"]
-      },
-      "enterprise": {
-        "name": "Doanh nghiệp",
-        "price": "Liên hệ",
-        "period": "mỗi tháng",
-        "description": "Cho doanh nghiệp lớn",
-        "features": ["Đội hỗ trợ chuyên biệt", "Bảo mật cấp doanh nghiệp"]
+        "description": "Tính năng nâng cao cho doanh nghiệp mở rộng",
+        "features": [
+          "20 gói tự động hóa upload",
+          "10 agent tạo mới",
+          "3 đơn vị tổ chức tạo mới",
+          "200 tin nhắn trợ lý AI",
+          "Mọi thứ trong Pro",
+          "Hỗ trợ ưu tiên",
+          "Phân tích nâng cao"
+        ]
       }
     },
     "faq": {

--- a/src/components/landingPage/newsletter.tsx
+++ b/src/components/landingPage/newsletter.tsx
@@ -9,7 +9,7 @@ import { TextPlugin } from 'gsap/TextPlugin'
 gsap.registerPlugin(ScrollTrigger, TextPlugin)
 
 export default function Newsletter() {
-  const t = useTranslations('landing')
+  const t = useTranslations('newsletter')
 
   const newsletterRef = useRef<HTMLDivElement>(null)
 
@@ -45,19 +45,19 @@ export default function Newsletter() {
 
         <div className="newsletter-content max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center relative z-10">
           <h2 className="text-4xl sm:text-5xl font-bold text-white mb-6">
-            {t('newsletter.title')}
+            {t('title')}
           </h2>
           <p className="text-xl text-orange-100 mb-10 max-w-2xl mx-auto">
-            {t('newsletter.description')}
+            {t('description')}
           </p>
           <div className="flex flex-col sm:flex-row gap-4 max-w-lg mx-auto">
             <input
               type="email"
-              placeholder={t('newsletter.placeholder')}
+              placeholder={t('placeholder')}
               className="flex-1 px-8 py-4 rounded-xl border-0 focus:ring-4 focus:ring-orange-200 focus:outline-none text-lg bg-white/90"
             />
             <button className="animated-button bg-white text-orange-600 px-10 py-4 rounded-xl font-semibold hover:bg-neutral-50 transition-colors whitespace-nowrap text-lg">
-              {t('newsletter.button')}
+              {t('button')}
             </button>
           </div>
         </div>

--- a/src/components/landingPage/pricing-plan.tsx
+++ b/src/components/landingPage/pricing-plan.tsx
@@ -15,27 +15,20 @@ export default function Pricing() {
 
   const pricingPlans = [
     {
-      name: t('pricing.basic.name'),
-      price: t('pricing.basic.price'),
-      period: t('pricing.basic.period'),
-      description: t('pricing.basic.description'),
-      features: t.raw('pricing.basic.features') as string[],
+      name: t('pricing.pro.name'),
+      price: t('pricing.pro.price'),
+      period: t('pricing.pro.period'),
+      description: t('pricing.pro.description'),
+      features: t.raw('pricing.pro.features') as string[],
       popular: false,
     },
     {
-      name: t('pricing.premium.name'),
-      price: t('pricing.premium.price'),
-      period: t('pricing.premium.period'),
-      description: t('pricing.premium.description'),
-      features: t.raw('pricing.premium.features') as string[],
+      name: t('pricing.ultra.name'),
+      price: t('pricing.ultra.price'),
+      period: t('pricing.ultra.period'),
+      description: t('pricing.ultra.description'),
+      features: t.raw('pricing.ultra.features') as string[],
       popular: true,
-    },
-    {
-      name: t('pricing.enterprise.name'),
-      price: t('pricing.enterprise.price'),
-      description: t('pricing.enterprise.description'),
-      features: t.raw('pricing.enterprise.features') as string[],
-      popular: false,
     },
   ]
 
@@ -72,7 +65,7 @@ export default function Pricing() {
             <p className="section-title text-xl text-neutral-400 max-w-3xl mx-auto"></p>
           </div>
 
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-10">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-10 max-w-4xl mx-auto">
             {pricingPlans.map((plan, index) => (
               <div
                 key={index}


### PR DESCRIPTION
Revised pricing plan structure by replacing 'Basic', 'Premium', and 'Enterprise' with 'Pro' and 'Ultra' tiers in both English and Vietnamese translations and updated their features. Adjusted pricing-plan.tsx to use the new plans and removed the third column. Updated newsletter.tsx to use the correct translation namespace and keys for improved consistency.